### PR TITLE
low memory wrapper function

### DIFF
--- a/pandas_dtype_efficiency.py
+++ b/pandas_dtype_efficiency.py
@@ -229,7 +229,7 @@ class DataFrameChecker:
     
     
     
-def lowmem(df: pd.DataFrame, categorical_threshold: int = 15, float_size: int = 16,verbose: bool =False):
+def lowmem(df: pd.DataFrame, categorical_threshold: int = 15, float_size: int = 32,verbose: bool =False):
     """
     Wrapper for dtype efficiency. Accepts identical arguments, with the addition of verbose.
     Allows for one-line use. 
@@ -259,12 +259,27 @@ def lowmem(df: pd.DataFrame, categorical_threshold: int = 15, float_size: int = 
     # Just use the example given in the readme.
     checker = DataFrameChecker(df=df,
                                categorical_threshold=categorical_threshold,  # Optional argument
-                               float_size=float_size)                        # Optional argument
-    
+                               float_size=float_size,
+                               verbose=verbose)                        # Optional argument
+    # Possible to add verbose comments into the following functions to make this truly silent.
     checker.identify_possible_improvements()
     low_mem=checker.cast_dataframe_to_lower_memory_version()    
     if verbose==True:
         df.memory_usage(deep=True)
         low_mem.memory_usage(deep=True)
     return low_mem
-
+    
+    
+def read_csv(file_path : str, categorical_threshold: int = 15, float_size: int = 32,verbose: bool =False,deep:bool=True,**kwargs):
+    """
+    Simplest wrapper for Pandas Efficiency.
+    One liner to load and read files. 
+    Takes file_path as the first Arg, followed by same defaults as pd_eff. Also accepts any Pandas arguments.
+    
+    `import pandas_dtype_efficiency as pd_eff`
+    `pd_eff.read_csv('yourfilepath.csv',sep=',',index=[0]')`
+    """
+    csv=pd.read_csv(file_path,low_memory=False,**kwargs)
+    low_mem_output=lowmem(csv,categorical_threshold,float_size,verbose)
+    if deep: low_mem_output=low_mem_output.copy(deep=True)
+    return low_mem_output

--- a/pandas_dtype_efficiency.py
+++ b/pandas_dtype_efficiency.py
@@ -226,3 +226,45 @@ class DataFrameChecker:
                 columns_by_dtype[data_type] = relevant_columns
 
         return columns_by_dtype
+    
+    
+    
+def lowmem(df: pd.DataFrame, categorical_threshold: int = 15, float_size: int = 16,verbose: bool =False):
+    """
+    Wrapper for dtype efficiency. Accepts identical arguments, with the addition of verbose.
+    Allows for one-line use. 
+    
+    checker = pd_eff.lowmem(pd.read_csv(..),
+                            categorical_threshold=10,  
+                            float_size=32,
+                            verbose=True)
+ 
+    Returns 
+    -------
+    pd.DataFrame
+        Low memory dataframe
+        
+    Parameters
+    ----------
+    df : pandas DataFrame
+        Data to be checked to see whether any columns could reduce their memory usage.
+    categorical_threshold : int (default 15)
+        The maximum number of distinct values in a column of strings to suggest transforming it into a categorical
+        column.
+    float_size : int (default 16)
+        The desired numpy float type; 16: numpy float16, 32: numpy float23, 64: numpy float64 (the pandas default).
+    verbose : bool (default False)
+        Print the dataframe sizes in Mb. 
+    """ 
+    # Just use the example given in the readme.
+    checker = DataFrameChecker(df=df,
+                               categorical_threshold=categorical_threshold,  # Optional argument
+                               float_size=float_size)                        # Optional argument
+    
+    checker.identify_possible_improvements()
+    low_mem=checker.cast_dataframe_to_lower_memory_version()    
+    if verbose==True:
+        df.memory_usage(deep=True)
+        low_mem.memory_usage(deep=True)
+    return low_mem
+


### PR DESCRIPTION
Hi there! Love your work, this is a game changer. However, its kind of annoying to have to call several arguments to get the low memory dataframe. 
So I wrote a quick wrapper from your docs. Feel free to merge or modify if you like the idea.

Basically wraps the three commands required to convert pd.DataFrames to low memory and returns that.

So instead now you can just call:
`lowmem=pd_eff.lowmem(df,args)` or even
`lowmem=pd_eff.lowmem(pd.read_csv(...),args)`


Bonus points if someone can wrap something like this this directly into pandas read_csv. But this is a nice start. 